### PR TITLE
Add working setup of Dangerfile with multiple imports

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # See https://github.com/danger/danger-js/issues/1042
+      DANGER_GITHUB_API_BASE_URL: "https://api.github.com"
     steps:
       # For debugging
       - name: Dump GitHub Context

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,48 @@
+name: Run Checks with Danger
+on:
+  pull_request:
+    # Because we have a rule that validates the PR labels, we want it to run
+    # when the labels change, not only when a PR is opened/reopened or changes
+    # are pushed to it.
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # For debugging
+      - name: Dump GitHub Context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+
+      - name: Install Yarn
+        run: npm install -g yarn
+
+      - name: Cache Node Modules
+        id: cache-node-modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-node_modules
+
+      - name: Yarn Install
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        # frozen-lockfile will make the build fail if the lockfile is not there
+        run: yarn install --frozen-lockfile
+
+      - name: Check Stuff with Danger ⚠️
+        # As a first step, let's verify the `ci` command can run a Dangerfile
+        # importing more Dangerfiles.
+        run: |
+          DEBUG="*" yarn run danger ci \
+            --dangerfile dangerfiles/multiple_checks.ts

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -43,8 +43,10 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Check Stuff with Danger ⚠️
-        # As a first step, let's verify the `ci` command can run a Dangerfile
-        # importing more Dangerfiles.
+        # Notice the use of the remote Dangerfile option. We've established
+        # Danger can resolve the imports when running locally in
+        # https://github.com/mokagio/danger-js-playground/pull/1/commits/b94cf3838a9c202597d0657104e42b5ecf5256d6,
+        # but can it when the Dangerfile is remote?
         run: |
           DEBUG="*" yarn run danger ci \
-            --dangerfile dangerfiles/multiple_checks.ts
+            --dangerfile mokagio/danger-js-playground/dangerfiles/multiple_checks.ts

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -49,4 +49,4 @@ jobs:
         # but can it when the Dangerfile is remote?
         run: |
           DEBUG="*" yarn run danger ci \
-            --dangerfile mokagio/danger-js-playground/dangerfiles/multiple_checks.ts
+            --dangerfile dangerfiles/multiple_checks.ts

--- a/dangerfiles/label.ts
+++ b/dangerfiles/label.ts
@@ -3,7 +3,7 @@
 //
 // import {warn, danger} from "danger";
 
-export default async function checkLabel() {
+export async function checkLabel() {
   const labels = danger.github.issue.labels;
 
   // Warn if the PR doesn't have any labels
@@ -15,3 +15,8 @@ export default async function checkLabel() {
   // warnings
 };
 
+// Not exactly sure why, but in order for the multiple files + import setup to
+// work we need to split the export of this function and its declaration as the
+// default export. I'm guessing it has to do with how TypeScript resolves
+// these?
+export default checkLabel

--- a/dangerfiles/milestone.ts
+++ b/dangerfiles/milestone.ts
@@ -3,7 +3,7 @@
 //
 // import {warn, danger} from "danger";
 
-export default async function checkMilestone() {
+export async function checkMilestone() {
   // Warn if the PR doesn't have a milestone
   const issue = await danger.github.api.issues.get(danger.github.thisPR);
   if (issue.data.milestone == null) {
@@ -14,3 +14,8 @@ export default async function checkMilestone() {
   // pattern or if there's a certain label.
 };
 
+// Not exactly sure why, but in order for the multiple files + import setup to
+// work we need to split the export of this function and its declaration as the
+// default export. I'm guessing it has to do with how TypeScript resolves
+// these?
+export default checkMilestone

--- a/dangerfiles/multiple_checks.ts
+++ b/dangerfiles/multiple_checks.ts
@@ -1,15 +1,8 @@
-// When importing a single file, the following syntax works too, but when 
-// importing more, it doesn't.
-//
-// import {checkMilestone} from "./milestone"
-//
-// Could it have to do with the fact that they're both exported as default?
-// So far, I've left the `export default` becuase it allows the source to be
-// run as a standalone Dangerfile
-import checkMilestone from "./milestone"
-import checkLabel from "./label"
-
 export default async () => {
+  // The imports need to be done within this async function.
+  const {checkLabel} = await import("./label.ts")
+  const {checkMilestone} = await import("./milestone.ts")
+
   await checkLabel()
   await checkMilestone()
 }


### PR DESCRIPTION
Worked on this as part of #1. I still haven't figured out how to make the _remote_ `Dangerfile` with imports work, but in the meantime I want to lock in this version.

I feel like it's worth pushing to `master` because I'm getting this error when using this code but referencing the `Dangerfile` remotely.

```
DANGER_GITHUB_API_TOKEN=*** \
DANGER_TEST_REPO=mokagio/danger-js-playground \
DANGER_FAKE_CI='yep' \
BRANCH=check-whether-remote-dangerfile-resolves-imports \
DANGER_TEST_PR='1' \
DEBUG='*' \
yarn run danger ci \
  --verbose \
  --dangerfile $DANGER_TEST_REPO/dangerfiles/multiple_checks.ts@$BRANCH
```

```
2020-05-21T10:59:04.783Z danger:runner Evaluating mokagio/danger-js-playground/dangerfiles/multiple_checks.ts@check-whether-remote-dangerfile-resolves-imports

2020-05-21T10:59:05.195Z danger:transpiler:setup Does not have Babel set up

2020-05-21T10:59:05.487Z danger:inline_runner Started parsing Dangerfile:  peril-downloaded-mokagio/danger-js-playground/dangerfiles/multiple_checks.ts@check-whether-remote-dangerfile-resolves-imports

2020-05-21T10:59:05.488Z danger:inline_runner Running default export from Dangerfile peril-downloaded-mokagio/danger-js-playground/dangerfiles/multiple_checks.ts@check-whether-remote-dangerfile-resolves-imports

Request failed [404]: https://api.github.com/repos/mokagio/danger-js-playground/contents//dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports.js

Response: {
  "message": "No commit found for the ref check-whether-remote-dangerfile-resolves-imports.js",
  "documentation_url": "https://developer.github.com/v3/repos/contents/"
}

Request failed [404]: https://api.github.com/repos/mokagio/danger-js-playground/contents//dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports.ts

Response: {
  "message": "No commit found for the ref check-whether-remote-dangerfile-resolves-imports.ts",
  "documentation_url": "https://developer.github.com/v3/repos/contents/"
}

Unable to evaluate the Dangerfile
 Error: Could not find './label.ts' as a relative import from mokagio/danger-js-playground/dangerfiles/multiple_checks.ts@check-whether-remote-dangerfile-resolves-imports. Does /dangerfiles/label.ts exist in the repo?
    at Object.<anonymous> (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:165:19)
    at step (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:32:23)
    at Object.next (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:13:53)
    at fulfilled (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:4:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

2020-05-21T10:59:06.314Z danger:inline_runner Got a parse error:  Error: Could not find './label.ts' as a relative import from mokagio/danger-js-playground/dangerfiles/multiple_checks.ts@check-whether-remote-dangerfile-resolves-imports. Does /dangerfiles/label.ts exist in the repo?
    at Object.<anonymous> (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:165:19)
    at step (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:32:23)
    at Object.next (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:13:53)
    at fulfilled (/Users/gio/Developer/mokagio/danger-js-playground/node_modules/danger/distribution/platforms/github/customGitHubRequire.js:4:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

What is happening, I think, is that Danger is appending the `.js` and `.ts` to the branch name when generating the URL for the resolved relative imports.

The URL with [`dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports.js`](https://api.github.com/repos/mokagio/danger-js-playground/contents//dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports.js) 404s, but [`dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports`](https://api.github.com/repos/mokagio/danger-js-playground/contents//dangerfiles/label.ts?ref=check-whether-remote-dangerfile-resolves-imports) succeeds.

So, my assumption is that if I remove the branch from the relative import resolution, things should work, or at least have a different error later in the flow.