### PR TITLE
PR to test whether Danger can resolve imports in remote Dangerfiles

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -49,4 +49,4 @@ jobs:
         # but can it when the Dangerfile is remote?
         run: |
           DEBUG="*" yarn run danger ci \
-            --dangerfile dangerfiles/multiple_checks.ts
+            --dangerfile mokagio/danger-js-playground/dangerfiles/multiple_checks.ts


### PR DESCRIPTION
Followup to #1.

I'm expecting it to work out of the box, because it does work when I run the `ci` command locally with `DANGER_FAKE_CI='yep'` etc. That is, we should see two warnings here, one for the missing label and one for the missing milestone. 